### PR TITLE
Time Utilties helper [REJECT]

### DIFF
--- a/src/OpenTracing/TimeUtilities.php
+++ b/src/OpenTracing/TimeUtilities.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace OpenTracing;
+
+use DateTimeImmutable;
+
+class TimeUtilities
+{
+    /**
+     * @return \DateTimeInterface
+     */
+    public function createFromMicrotime($microtime)
+    {
+        if (is_float($microtime)) {
+            $format = 'U.u';
+        } else if (is_int($microtime)) {
+            $format = 'U';
+        } else if (is_string($microtime)) {
+            $format = 'U u';
+        } else {
+            throw new \InvalidArgumentException(
+                'Given argument is not a known microtime format,
+                which is either a float,
+                string with format "sec msec" or unix timestamp integer for the full second.'
+            );
+        }
+
+        $date = DateTimeImmutable::createFromFormat($format, $microtime);
+
+        if (!$date) {
+            throw new \InvalidArgumentException(
+                'Given argument is not a known microtime format,
+                which is either a float,
+                string with format "sec msec" or unix timestamp integer for the full second.'
+            );
+        }
+
+        return $date;
+    }
+
+    /**
+     * @return \DateTimeInterface
+     */
+    public function now()
+    {
+        return self::createFromMicrotime(microtime(true));
+    }
+}

--- a/tests/OpenTracing/TimeUtilitiesTest.php
+++ b/tests/OpenTracing/TimeUtilitiesTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace OpenTracing;
+
+class TimeUtilitiesTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider dataValidMicrotimes
+     */
+    public function testCreateFromValidMicrotimes($expected, $microtime)
+    {
+        $date = TimeUtilities::createFromMicrotime($microtime);
+        $this->assertEquals($expected, $date->format('Y-m-d H:i:s.u'));
+    }
+
+    public function dataValidMicrotimes()
+    {
+        return [
+            ['2009-02-13 23:31:30.123500', 1234567890.123456],
+            ['2019-01-19 09:28:32.222200', 1547890112.222222],
+        ];
+    }
+}


### PR DESCRIPTION
**NOTE**: This is documenting a potential helper to work with microsecond precision and DateTime, however its loosing precision after 4 digits, even though technically it can render 6.

I would suggest we abandon the use of any kind of DateTime or other abstraction in the OT API itself and stick to float only, as done in the hellofresh implementation: https://github.com/hellofresh/opentracing-php/blob/master/src/OpenTracing/TracerInterface.php#L29