### PR TITLE
Represent Timestamps as float

### DIFF
--- a/src/OpenTracing/Span.php
+++ b/src/OpenTracing/Span.php
@@ -2,8 +2,6 @@
 
 namespace OpenTracing;
 
-use DateTime;
-
 interface Span
 {
     /**
@@ -19,10 +17,14 @@ interface Span
 
     /**
      * @param string $event
+     * @param float $timestamp
      */
-    public function log($event, array $fields = [], DateTime $timestamp = null);
+    public function log($event, array $fields = [], $timestamp = null);
 
-    public function finish(DateTime $timestamp = null);
+    /**
+     * @param float $timestamp
+     */
+    public function finish($timestamp = null);
 
     /**
      * @param string $name

--- a/src/OpenTracing/SpanOptions.php
+++ b/src/OpenTracing/SpanOptions.php
@@ -20,7 +20,7 @@ class SpanOptions
     private $tags = array();
 
     /**
-     * @var \DateTimeInterface
+     * @var float
      */
     private $startTime;
 
@@ -60,10 +60,10 @@ class SpanOptions
 
                 case 'startTime':
                 case 'start_time':
-                    if (!($value instanceof \DateTimeInterface)) {
+                    if (!is_int($value) && !is_float($value)) {
                         throw new \InvalidArgumentException(sprintf(
-                            'Property "%s" must be \DateTimeInterface, is: %s',
-                            $property,
+                            'Property "%s" must be float|int, is: %s',
+                            $key,
                             is_object($value) ? get_class($value) : gettype($value)
                         ));
                     }

--- a/tests/OpenTracing/SpanOptionsTest.php
+++ b/tests/OpenTracing/SpanOptionsTest.php
@@ -14,7 +14,7 @@ class SpanOptionsTest extends \PHPUnit_Framework_TestCase
         $options = new SpanOptions(array(
             'childOf' => $context,
             'tags' => array('foo' => 'bar'),
-            'startTime' => $date = new DateTime(),
+            'startTime' => $date = microtime(true),
         ));
 
         $this->assertSame($context, $options->getChildOf());
@@ -23,7 +23,7 @@ class SpanOptionsTest extends \PHPUnit_Framework_TestCase
 
         $options = new SpanOptions(array(
             'child_of' => $context,
-            'start_time' => $date = new DateTime(),
+            'start_time' => $date = microtime(true),
         ));
 
         $this->assertSame($context, $options->getChildOf());


### PR DESCRIPTION
Move from DateTime to float to be as precise as possible with dates in PHP, no other way.

As shown in #1 DateTime is only precise up to 4 digits and looses everything after that. Depending on the tracer implementation this is not good enough. Using a float leaves everything open.